### PR TITLE
Added @export to pass check()

### DIFF
--- a/R/textfeatureinfor.R
+++ b/R/textfeatureinfor.R
@@ -108,6 +108,7 @@ avg_word_len <- function(text) {
 #' @param text A character vector with length one containing the piece of text to analyze.
 #'
 #' @return A vector containing the number of fully capitalised words
+#' @export
 #'
 #' @examples
 #' text <- "This is REALLY Awesome!"
@@ -141,6 +142,7 @@ perc_cap_words <- function(text) {
 #' @param text A character vector with length one containing the piece of text to analyze.
 #'
 #' @return A character vector containing words in the text that are not stop words.
+#' @export
 #'
 #' @examples
 #' text <- "Tomorrow is a big day!"


### PR DESCRIPTION
I noticed that `perc_cap_words` and `remove_stop_words` are missing the **`@export`** in their docstrings, which were causing the errors (like `Error in perc_cap_words(text) : could not find function “perc_cap_words”`) after running devtools::check(). 